### PR TITLE
Rails 4.2 fix related to reflections

### DIFF
--- a/lib/themis/ar/use_validation_method.rb
+++ b/lib/themis/ar/use_validation_method.rb
@@ -45,7 +45,7 @@ module Themis
       # Affect associations that are already loaded.
       # @param [Symbol] association_name
       def affect_association(association_name)
-        unless @model.class.reflections.has_key?(association_name)
+        unless @model.class.reflect_on_association(association_name)
           raise("`#{association_name}` is not an association on #{@model.class}")
         end
 


### PR DESCRIPTION
Rails 4.2 now uses [strings for reflection keys instead of symbols](https://github.com/rails/rails/issues/16928).  This PR fixes Themis to take that into consideration.
